### PR TITLE
Update version number to differentiate it

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-cli</artifactId>
-    <version>0.110</version>
+    <version>0.110-cli1</version>
     <name>Mojito - CLI</name>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
- add the -cli1 suffix so that we know it is different than the standard 0.110 cli jar.
- idea is to increment the number after the "cli" part as we make new versions