### PR TITLE
Prevent empty drop creation when locales are specified

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
@@ -161,9 +161,9 @@ public class DropExportCommand extends Command {
         return bcp47tags;
     }
     
-    private boolean shouldCreateDrop(Repository repository) {
+    private boolean shouldCreateDrop(Repository repository) throws CommandException {
         boolean createDrop = false;
-        Set<String> Bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExportFromRepository(repository));
+        Set<String> Bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExport(repository));
         RepositoryStatistic repoStat = repository.getRepositoryStatistic();
         if (repoStat != null) {
             for (RepositoryLocaleStatistic repoLocaleStat : repoStat.getRepositoryLocaleStatistics()) {


### PR DESCRIPTION
Currently, running
```
$ mojito drop-export -r Demo -l de-DE,fr-FR
```
when there are no strings to translate in DE or FR creates an empty drop if there are some strings to translate in _other_ locales of specified repo.

In this scenario, because there is nothing to export for specified locales, drop should not be created (message `Repository is already fully translated`).